### PR TITLE
add small and lang tags

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -442,6 +442,9 @@ class Markup_12y2 { constructor() {
 				} break; case '\\sup': {
 					OPEN('superscript')
 					word_maybe()
+				} break; case '\\small': {
+					OPEN('small')
+					word_maybe()
 				} break; case '\\b': {
 					OPEN('bold')
 					word_maybe()
@@ -490,6 +493,10 @@ class Markup_12y2 { constructor() {
 					if (!is_color(color))
 						color = null
 					OPEN('background_color', {color})
+				} break; case '\\lang': {
+					let [lang] = rargs
+					OPEN('language', {lang})
+					word_maybe()
 				}}
 			} break; case 'STYLE': {
 				let c = check_style(token, text.charAt(match.index-1)||"\n", text.charAt(REGEX.lastIndex)||"\n")

--- a/render.js
+++ b/render.js
@@ -297,6 +297,8 @@ we should create our own fake bullet elements instead.*/
 		
 		superscript: 𐀶`<sup>`,
 		
+		small: 𐀶`<small>`,
+		
 		/*anchor: function({name}) {
 			let e = this()
 			e.id = "Markup-anchor-"+name
@@ -326,6 +328,12 @@ we should create our own fake bullet elements instead.*/
 				e.dataset.bgcolor = color
 			return e
 		}.bind(𐀶`<span class='M-background'>`),
+		
+		language: function({lang}) {
+			let e = this()
+			e.lang = lang
+			return e
+		}.bind(𐀶`<span>`),
 		
 		invalid: function({text, reason}) {
 			let e = this()


### PR DESCRIPTION
there they are yay.

if you need a not-researched test document, here:

```12y2
\lang[en]{Hello, world!}
\lang[ja]{こんにちは、世界！}

gay \small{braixen} animal..
gay \sup{\sub{braixen}} animal..

\small{hey\small{hey\small{hey}}}
\sup{\sub{hey\sup{\sub{hey\sup{\sub{hey}}}}}}

\lang[zh]{
this is all in a `zh` block right now, so chinese is favored.

but here's japanese text:

# \lang[ja] \bg[green]本当に日本語で読みます。
# \lang[ja] 本当に \bg[red]日本語で読みます。

spaces can end the language block if you're not careful. according to `maybe_word()` rules.

# \lang[zh]{\b{本当に}日本語で読み\u{ません}。}
}

we're now back outside the block. default browser language prevails.
```