### PR TITLE
emote tag 

### DIFF
--- a/markup.css
+++ b/markup.css
@@ -119,7 +119,7 @@ L + ratio { }
 	height: auto;
 }	
 
-.Markup .M-emote {
+.Markup .M-emote, .M-emote {
 	display: inline-block;
 	object-fit: contain;
 	width: calc(var(--size)*var(--emote-size, 1.125em));
@@ -127,6 +127,7 @@ L + ratio { }
 	vertical-align: middle;
 	max-height: unset;
 	border: none;
+	margin-bottom: 0.125em;
 }
 
 .M-filter-h {
@@ -135,17 +136,17 @@ L + ratio { }
 .M-filter-v {
 	transform: scaleY(-1);
 }
-.M-filter-h.M-image-filter-v {
+.M-filter-h.M-filter-v {
 	transform: scaleX(-1) scaleY(-1);
 }
 .M-filter-r {
 	transform: rotate(90deg);
 }
 .M-filter-h.M-filter-r {
-	transform: scaleX(-1) rotate(90deg);
+	transform: rotate(90deg) scaleX(-1);
 }
 .M-filter-v.M-filter-r {
-	transform: scaleY(-1) rotate(90deg);
+	transform: rotate(90deg) scaleY(-1);
 }
 .M-filter-h.M-filter-v.M-filter-r {
 	transform: rotate(270deg);

--- a/markup.css
+++ b/markup.css
@@ -119,6 +119,42 @@ L + ratio { }
 	height: auto;
 }	
 
+.Markup .M-emote {
+	display: inline-block;
+	object-fit: contain;
+	width: calc(var(--size)*var(--emote-size, 1.125em));
+	height: calc(var(--size)*var(--emote-size, 1.125em));
+	vertical-align: middle;
+	max-height: unset;
+	border: none;
+}
+
+.M-filter-h {
+	transform: scaleX(-1);
+}
+.M-filter-v {
+	transform: scaleY(-1);
+}
+.M-filter-h.M-image-filter-v {
+	transform: scaleX(-1) scaleY(-1);
+}
+.M-filter-r {
+	transform: rotate(90deg);
+}
+.M-filter-h.M-filter-r {
+	transform: scaleX(-1) rotate(90deg);
+}
+.M-filter-v.M-filter-r {
+	transform: scaleY(-1) rotate(90deg);
+}
+.M-filter-h.M-filter-v.M-filter-r {
+	transform: rotate(270deg);
+}
+.M-filter-p {
+	image-rendering: pixelated;
+	image-rendering: crisp-edges;
+}
+
 /* ruby text doesn't work if set to white-space: pre */
 .Markup rt {
 	white-space: pre-line;

--- a/parse.js
+++ b/parse.js
@@ -422,7 +422,7 @@ class Markup_12y2 { constructor() {
 				read_args()
 				if (token==='\\link') {
 					read_body(false)
-				} else {
+				} else if (token!=='\\e') { // Emote should not have body
 					read_body(true)
 					if (NO_ARGS===rargs && false===body) {
 						NEVERMIND()
@@ -504,6 +504,10 @@ class Markup_12y2 { constructor() {
 					let [lang=""] = rargs
 					OPEN('language', {lang})
 					word_maybe()
+				} break; case '\\e': {
+					let [id="",name="",role="emote",source=""] = rargs.reverse()
+					OPEN('emote', {source, name, id, role})
+					CLOSE()
 				}}
 			} break; case 'STYLE': {
 				let c = check_style(token, text.charAt(match.index-1)||"\n", text.charAt(REGEX.lastIndex)||"\n")

--- a/render.js
+++ b/render.js
@@ -122,14 +122,18 @@ class Markup_Render_Dom { constructor() {
 			return e
 		},
 
-		emote: function({source, name, id, role}) {
+		emote: function({source, name, id, role, filter}, filter2) {
 			if (id == "") id = name
 			if (role == "") role = "emote"
 			let options
 			[id, options=""] = id.split("#")
+			options+=(filter || "") + (filter2 || "")
+			let opt = {}
+			// Duplicate filters cancel out
+			options.split('').forEach(c=>opt[c] = !opt[c])
 			let url, unknown = false
 			if (id) 
-				url = (EMOTE_SOURCES[source] || EMOTE_SOURCES.UNKNOWN)(id, {pixel: options.indexOf("p") != -1})
+				url = (EMOTE_SOURCES[source] || EMOTE_SOURCES.UNKNOWN)(id, {pixel: opt["p"]})
 			let src = filter_url(url || "data:image/gif;base64,R0lGODlhAQABAIAAANDL5NDL5CH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==", 'image')
 			let e = document.createElement('img')
 			e.classList.add('M-emote')
@@ -165,7 +169,7 @@ class Markup_Render_Dom { constructor() {
 			e.style.setProperty('--size', size)
 			set_size('size', size * 16, size * 16)
 			e.src = src
-			options.split("").forEach(x => e.classList.add(`M-filter-${x}`))
+			Object.keys(opt).forEach(x => x ? e.classList.add(`M-filter-${x}`) : undefined)
 			// check whether the image is "available" (i.e. size is known) by looking at naturalHeight
 			// https://html.spec.whatwg.org/multipage/images.html#img-available
 			// this will happen here if the image is VERY cached, i guess

--- a/render.js
+++ b/render.js
@@ -29,6 +29,12 @@ class Markup_Render_Dom { constructor() {
 		ERROR: (href, thing)=> "about:blank#"+href,
 	}
 	
+	let EMOTE_SOURCES = {
+		__proto__: null,
+		"url": (id, role) => id,
+		"discord": (id, role) => role == "sticker" ? `https://media.discordapp.net/stickers/${id}` : `https://cdn.discordapp.com/emojis/${id}`
+	}
+	
 	function filter_url(url, thing) {
 		try {
 			let u = new URL(url, "no-scheme:/")
@@ -107,6 +113,68 @@ class Markup_Render_Dom { constructor() {
 			else // otherwise wait for load
 				e.decode().then(ok=>{
 					set_size('loaded')
+				}, no=>{
+					e.dataset.state = 'error'
+				})
+			return e
+		},
+
+		emote: function({source, name, id, role}) {
+			let url = "data:image/gif;base64,R0lGODlhAQABAIAAANDL5NDL5CH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
+			if (id == "") id = name
+			if (role == "") role = "emote"
+			let options
+			[id, options=""] = id.split("#")
+			let pixel = options.indexOf("p") != -1
+			if (id) {
+				if (source == "") {
+					url = pixel ? `sbs:image/${id}` : `sbs:image/${id}?size=128`
+				} else if (EMOTE_SOURCES[source]) {
+					url = EMOTE_SOURCES[source](id, role)
+				}
+			}
+			let src = filter_url(url, 'image')
+			let e = document.createElement('img')
+			e.classList.add('M-emote')
+			if (name!=null)
+				e.alt = e.title = name
+			e.tabIndex = 0
+			const set_size = (state, width=e.naturalWidth, height=e.naturalHeight)=>{
+				if (state=="size") {
+					e.width = width
+					e.height = height
+				}
+				e.style.setProperty('--width', width)
+				e.style.setProperty('--height', height)
+				e.dataset.state = state
+			}
+			let size = 2
+			switch (role) {
+				case "icon":
+					size = 1
+					break
+				case "emote":
+					size = 2
+					break
+				case "medium":
+					size = 4
+					break
+				case "sticker":
+					size = 8
+					break
+			}
+			e.style.setProperty('--size', size)
+			set_size('size', size * 16, size * 16)
+			e.src = src
+			options.split("").forEach(x => e.classList.add(`M-filter-${x}`))
+			// check whether the image is "available" (i.e. size is known) by looking at naturalHeight
+			// https://html.spec.whatwg.org/multipage/images.html#img-available
+			// this will happen here if the image is VERY cached, i guess
+			if (e.naturalHeight)
+				set_size('loaded-emote')
+			else // otherwise wait for load
+				e.decode().then(ok=>{
+					set_size('loaded-emote')
 				}, no=>{
 					e.dataset.state = 'error'
 				})
@@ -416,6 +484,7 @@ we should create our own fake bullet elements instead.*/
 		@member {Object<string,function>}
 	**/
 	this.url_scheme = URL_SCHEME
+	this.emote_sources = EMOTE_SOURCES
 	this.filter_url = filter_url
 }}
 

--- a/render.js
+++ b/render.js
@@ -31,8 +31,11 @@ class Markup_Render_Dom { constructor() {
 	
 	let EMOTE_SOURCES = {
 		__proto__: null,
-		"url": (id, role) => id,
-		"discord": (id, role) => role == "sticker" ? `https://media.discordapp.net/stickers/${id}` : `https://cdn.discordapp.com/emojis/${id}`
+		"": (id, options) => options.pixel ? `sbs:image/${id}` : `sbs:image/${id}?size=128`,
+		"url": (id, options) => id,
+		"discordemote": (id, options) => `https://cdn.discordapp.com/emojis/${id}`,
+		"discordsticker": (id, options) => `https://media.discordapp.net/stickers/${id}`,
+		UNKNOWN: (id, options) => null
 	}
 	
 	function filter_url(url, thing) {
@@ -120,22 +123,18 @@ class Markup_Render_Dom { constructor() {
 		},
 
 		emote: function({source, name, id, role}) {
-			let url = "data:image/gif;base64,R0lGODlhAQABAIAAANDL5NDL5CH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
 			if (id == "") id = name
 			if (role == "") role = "emote"
 			let options
 			[id, options=""] = id.split("#")
-			let pixel = options.indexOf("p") != -1
-			if (id) {
-				if (source == "") {
-					url = pixel ? `sbs:image/${id}` : `sbs:image/${id}?size=128`
-				} else if (EMOTE_SOURCES[source]) {
-					url = EMOTE_SOURCES[source](id, role)
-				}
-			}
-			let src = filter_url(url, 'image')
+			let url, unknown = false
+			if (id) 
+				url = (EMOTE_SOURCES[source] || EMOTE_SOURCES.UNKNOWN)(id, {pixel: options.indexOf("p") != -1})
+			let src = filter_url(url || "data:image/gif;base64,R0lGODlhAQABAIAAANDL5NDL5CH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==", 'image')
 			let e = document.createElement('img')
 			e.classList.add('M-emote')
+			e.dataset.emotesource = source
+			if (url == null) e.dataset.emoteunknown = true
 			if (name!=null)
 				e.alt = e.title = name
 			e.tabIndex = 0

--- a/render.js
+++ b/render.js
@@ -31,7 +31,7 @@ class Markup_Render_Dom { constructor() {
 	
 	let EMOTE_SOURCES = {
 		__proto__: null,
-		"": (id, options) => options.pixel ? `sbs:image/${id}` : `sbs:image/${id}?size=128`,
+		"": (id, options) => options.pixel ? `sbs:image/${id}` : `sbs:image/${id}?size=200`,
 		"url": (id, options) => id,
 		"discordemote": (id, options) => `https://cdn.discordapp.com/emojis/${id}`,
 		"discordsticker": (id, options) => `https://media.discordapp.net/stickers/${id}`,


### PR DESCRIPTION
implements emotes in a minimum way  
\e[source;role;name;id]  
(note: this reads in a reverse order; the other forms are \e[id], \e[name;id], and \e[role;name;id])
- source: where to source the emote from. if empty, uses `sbs:image/id` syntax. other included sources: URL, and discord
- role: specifies the size to display the emote at
- name: used for the alt text. (if id is also missing for some reason, it defaults to the name.)
- id: the emote that should be loaded. source specific in how it's handled.
it's also possible to include filters after this, by separating them from the id with a `#`
  - h, v: flips image horizontally and vertically, respectively
  - r: rotates image 90 degrees
  - p: sets the image to render with image-rendering set to pixelated/crisp-edges. also requests original resolution images for default source. (i would've done something like with pixel avatars and made them display pixel perfectly but i didn't feel like doing so right now. maybe it should also be a separate flag anyway)

there's multi-source support so that it may be extended by a frontend. (theoretical example? allow users to create a personal mapping for emotes? like source "user-5" could try searching for a page by user 5 that's marked in a way. idk. it could also just point to a hardcoded list.)

example syntax:
```
So... \e[icon;star bit;imagehash1]\bg[purple]{chunks}, huh?
---
yeah \e[sticker;flareon;imagehash2#hp]\e[url;medium;thumbs up paw;https://example.com/image.png]
---
\e[imagehash3]\e[imagehash3#h]\e[imagehash3#v]\e[imagehash3#r]\e[imagehash3#hv]\e[imagehash3#hr]\e[imagehash3#vr]\e[rimagehash3#hvr] look at my marios
---
\e[discordsticker;sticker;headphones kirby vibing;901150326533550120]\e[discordsticker;sticker;headphones kirby vibing;901150326533550120]\e[discordsticker;sticker;headphones kirby vibing;901150326533550120] listening to static noise
```
renders as such:
<img width="734" height="425" alt="post that demonstrates emotes in varying sizes, displayed inline alongside the text, some also being rotated and flipped" src="https://github.com/user-attachments/assets/a0b4b4f2-8cc4-45bd-a757-10cf56cba5b4" />

subject to change?:
- role names
- what resolution images get requested at by default for sbs:image (on my computer, 'sticker' size emotes display at 144px, whereas the size query param always uses 128px no matter the role)
- the whole "args get read in reverse" thing
- vertical-align? it's currently set to middle, but i did see that a previous comment suggested a value for this. however, it's only for icon sized emotes, and there doesn't seem to way offset the images from the middle position in a convenient manner. (setting margins with negative values causes images to overlap with elements on other lines.)

maybe not subject to change:
- syntax, overall. might be more of a frontend's job to handle entering emotes and conversion between internal syntax and user entered text? shrug

other notes:
- discord default stickers don't work cause they're canvas rendered vector things but that probably doesn't like matter
- baseline emote size can be overridden with a CSS variable. maybe useful to have as a frontend option